### PR TITLE
Add crypto news agent with external news tool

### DIFF
--- a/docker/langgraph/app/agents/news_agent/graph.py
+++ b/docker/langgraph/app/agents/news_agent/graph.py
@@ -1,0 +1,102 @@
+from typing import Annotated, TypedDict, List, Any, Union
+
+import boto3
+from pydantic import BaseModel, Field
+from langchain_aws import ChatBedrockConverse
+from langchain_core.messages import HumanMessage
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.runnables import RunnableLambda, RunnableConfig
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import StateGraph, START
+from langgraph.graph.message import add_messages
+from langgraph.prebuilt import ToolNode, tools_condition
+
+from tools.news_tools import fetch_crypto_news_tool
+
+
+class State(TypedDict):
+    messages: Annotated[List[Any], add_messages]
+
+
+def build_graph(
+    model: str = "anthropic.claude-3-haiku-20240307-v1:0",
+    provider: str = "anthropic",
+    temperature: float = 0,
+    tools = [fetch_crypto_news_tool],
+    system_prompt: str = (
+        "You are a news agent that finds recent crypto-related news for user queries. "
+        "Use available tools to gather information and present concise summaries."
+    ),
+):
+    bedrock = boto3.client("bedrock-runtime", region_name="us-east-1")
+    llm = ChatBedrockConverse(
+        model=model,
+        provider=provider,
+        temperature=temperature,
+        client=bedrock,
+    )
+
+    llm_with_tools = llm.bind_tools(tools)
+    prompt = ChatPromptTemplate.from_messages([
+        ("system", f"{system_prompt}"),
+        ("placeholder", "{messages}"),
+    ])
+    news_agent_chain = prompt | llm_with_tools
+
+    async def news_agent(state: State, config: RunnableConfig):
+        response = await news_agent_chain.ainvoke({"messages": state["messages"]}, config=config)
+        return {"messages": [response]}
+
+    memory = MemorySaver()
+    graph_builder = StateGraph(State)
+    graph_builder.add_node("news_agent", news_agent)
+    tool_node = ToolNode(tools=tools)
+    graph_builder.add_node("tools", tool_node)
+    graph_builder.add_conditional_edges("news_agent", tools_condition)
+    graph_builder.add_edge("tools", "news_agent")
+    graph_builder.add_edge(START, "news_agent")
+    graph = graph_builder.compile(checkpointer=memory)
+    graph.name = "NewsAgentGraph"
+    return graph
+
+
+class NewsGraphArgs(BaseModel):
+    query: str = Field(..., description="Topic for crypto news search")
+    retries: int = Field(0, ge=0, le=2, description="How many times the agent may loop")
+
+
+class NewsGraphResult(BaseModel):
+    articles: str = Field("", description="News articles or summary")
+    tools_used: List[str] = Field(default_factory=list, description="Tools executed in order")
+
+
+def _to_state(args: Union[NewsGraphArgs, dict]) -> State:
+    if isinstance(args, dict):
+        user_query = args.get("query", "")
+    else:
+        user_query = args.query
+    return {"messages": [HumanMessage(content=user_query)]}
+
+
+def _from_state(st: State) -> NewsGraphResult:
+    text = st["messages"][-1].content if st.get("messages") else ""
+    tools_used = []
+    for m in st["messages"]:
+        name = getattr(m, "name", "")
+        if name == "fetch_crypto_news":
+            tools_used.append(name)
+    seen = set()
+    ordered_tools = []
+    for t in tools_used:
+        if t not in seen:
+            ordered_tools.append(t)
+            seen.add(t)
+    return NewsGraphResult(articles=text, tools_used=ordered_tools)
+
+
+pipeline = RunnableLambda(_to_state) | build_graph() | RunnableLambda(_from_state)
+news_graph_tool = pipeline.as_tool(
+    args_schema=NewsGraphArgs,
+    name="run_news_agent_graph",
+    description="Runs the NewsAgentGraph and returns crypto news articles using tools.",
+)

--- a/docker/langgraph/app/tools/news_tools.py
+++ b/docker/langgraph/app/tools/news_tools.py
@@ -1,0 +1,43 @@
+import os
+import json
+import requests
+from pydantic import BaseModel, Field
+from langchain_core.tools import StructuredTool
+
+
+class FetchNewsInput(BaseModel):
+    query: str = Field(..., description="Search topic for crypto news")
+
+
+def fetch_crypto_news(query: str) -> str:
+    """Fetch recent crypto-related news articles for a given topic."""
+    api_key = os.getenv("NEWS_API_KEY")
+    if not api_key:
+        return json.dumps({"status": "ERROR", "error": "NEWS_API_KEY not set"})
+
+    url = "https://newsapi.org/v2/everything"
+    params = {
+        "q": f"{query} AND crypto",
+        "language": "en",
+        "sortBy": "publishedAt",
+        "apiKey": api_key,
+    }
+    try:
+        response = requests.get(url, params=params, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+        articles = [
+            {"title": a.get("title"), "url": a.get("url")}
+            for a in data.get("articles", [])[:5]
+        ]
+        return json.dumps({"status": "OK", "articles": articles}, indent=2)
+    except Exception as e:
+        return json.dumps({"status": "ERROR", "error": str(e)})
+
+
+fetch_crypto_news_tool = StructuredTool.from_function(
+    func=fetch_crypto_news,
+    name="fetch_crypto_news",
+    description="Fetch recent crypto-related news articles.",
+    args_schema=FetchNewsInput,
+)

--- a/tests/test_news_tools.py
+++ b/tests/test_news_tools.py
@@ -1,0 +1,15 @@
+import json
+from tools.news_tools import fetch_crypto_news_tool
+
+
+def test_fetch_crypto_news_tool(mocker):
+    mocker.patch.dict("tools.news_tools.os.environ", {"NEWS_API_KEY": "test"})
+    mock_response = mocker.Mock()
+    mock_response.json.return_value = {
+        "articles": [{"title": "Mock headline", "url": "http://example.com"}]
+    }
+    mock_response.raise_for_status.return_value = None
+    mocker.patch("tools.news_tools.requests.get", return_value=mock_response)
+    result = fetch_crypto_news_tool.invoke({"query": "bitcoin"})
+    data = json.loads(result)
+    assert data["articles"][0]["title"] == "Mock headline"


### PR DESCRIPTION
## Summary
- implement `fetch_crypto_news` tool for querying recent crypto headlines
- build `news_agent` LangGraph that uses the news tool to respond to user prompts
- add unit test for news tool with patched API calls

## Testing
- `PYTHONPATH=docker/langgraph/app pytest tests/test_news_tools.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6893c1c81cc0833294b8eba98c95d2ba